### PR TITLE
Update memory.go

### DIFF
--- a/pip/memory/memory.go
+++ b/pip/memory/memory.go
@@ -20,7 +20,7 @@ func (m mempip) Graph() ngac.Graph {
 	return m.graph
 }
 
-func (m mempip) Prohibitions() ngac.Prohibitions {
+func (m mempip) Prohibitions() ngac.Prohibition {
 	return m.prohibitions
 }
 


### PR DESCRIPTION
Updated from 
func (m mempip) Prohibitions() ngac.Prohibitions
to
func (m mempip) Prohibitions() ngac.Prohibition
The Prohibitions() returns a struct, not an interface.